### PR TITLE
Add probe marker option to indicate the existence of INT in IP TCP/UDP packets

### DIFF
--- a/telemetry/specs/INT.mdk
+++ b/telemetry/specs/INT.mdk
@@ -414,8 +414,8 @@ retaining ECMP behavior is desired, probe marker option could be followed.
 With arbitrary values being inserted after TCP/UDP header in probe marker
 option, the likelihood of conflicting with user traffic in a data center is 
 low, but cannot be completely eliminated. To further reduce the chance of 
-conflict, a user deploys probe marker option could choose to check more into
-port number to identify the existence of INT.) 
+conflict, the user who deploys probe marker option could choose to check more 
+into TCP/UDP port numbers to identify the existence of INT.) 
 
 
 INT over TCP/UDP adds INT metadata after TCP/UDP headers as if the payload is

--- a/telemetry/specs/INT.mdk
+++ b/telemetry/specs/INT.mdk
@@ -404,7 +404,12 @@ the reserved or configured values are
 per domain decisions that all INT capable devices should follow. (Note: in
 general, encoding into DSCP field will be less intrusive compared to changing
 the layer 4 port field. The latter may alter ECMP behavior and can complicate
-ACL and network debugging.)
+ACL and network debugging. If DSCP field can not be reseved for INT, and 
+retaining ECMP behavior is desired, adding probe marker fields could be an
+option. With arbitary values being inserted after TCP/UDP header, the chance
+to conflict with user traffic in a data center is low, but can not be completely 
+eliminated.)
+
 
 INT over TCP/UDP adds INT metadata after TCP/UDP headers as if the payload is
 changed. However, the sink device will remove INT headers before passing the

--- a/telemetry/specs/INT.mdk
+++ b/telemetry/specs/INT.mdk
@@ -371,7 +371,7 @@ both INT header stacks carry information for respective layers and need not be
 considered interfering with each other.)
 
 A field in the lower layers of Ethernet, IP, or TCP/UDP should indicate if the
-INT header exists after the TCP/UDP header. We propose two options:
+INT header exists after the TCP/UDP header. We propose three options:
 
 * IPv4 DSCP or IPv6 Traffic Class field: A value or a bit will be reserved to
 indicate the existence of INT after TCP/UDP. INT source will put the reserved
@@ -384,8 +384,23 @@ ignore the designated bit position.)
 * TCP/UDP destination Port field: A port number in layer 4 will be reserved to
 indicate the existence of INT after TCP/UDP. INT source changes the destination
 Port, and sink must restore the original port number.
+* New Probe Marker fields: arbitrary 32-bit values are inserted after IP TCP/UDP header
+to indicate the existence of INT after TCP/UDP. These fileds should be interpreted
+as unsigned integer values and are initialized to a configured value. 
 
-The decision to use DSCP or destination port field and the reserved values are
+INT probe marker for TCP/UDP:
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                         Probe Marker (1)                      |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                         Probe Marker (2)                      |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
+The decision to use DSCP, destination port field or probe marker, and 
+the reserved or configured values are
 per domain decisions that all INT capable devices should follow. (Note: in
 general, encoding into DSCP field will be less intrusive compared to changing
 the layer 4 port field. The latter may alter ECMP behavior and can complicate

--- a/telemetry/specs/INT.mdk
+++ b/telemetry/specs/INT.mdk
@@ -388,8 +388,9 @@ Port, and sink must restore the original port number.
 header to indicate the existence of INT after TCP/UDP. These fields should be 
 interpreted as unsigned integer values, stored in network byte order and are 
 initialized to a configured value.  This Probe marker is a variation of an early 
-IETF draft with existing implementations. More information can be found at 
-https://tools.ietf.org/html/draft-lapukhov-dataplane-probe-01.
+IETF draft with existing implementations [^DPP].
+[^DPP] : Data-plane probe for in-band telemetry collection,
+https://tools.ietf.org/html/draft-lapukhov-dataplane-probe-01
 
 INT probe marker for TCP/UDP:
 
@@ -415,7 +416,7 @@ With arbitrary values being inserted after TCP/UDP header in probe marker
 option, the likelihood of conflicting with user traffic in a data center is 
 low, but cannot be completely eliminated. To further reduce the chance of 
 conflict, the user who deploys probe marker option could choose to check more 
-into TCP/UDP port numbers to identify the existence of INT.) 
+into TCP/UDP port numbers to validate INT probe marker) 
 
 
 INT over TCP/UDP adds INT metadata after TCP/UDP headers as if the payload is


### PR DESCRIPTION
As discussed at P4 application meeting on Jan 18,  a new proposal was presented to satisfy certain deployment scenarios, where DSCP field can't be assigned for INT,  and TCP/UDP ports need to be kept to retain ECMP behavior.   With this proposal, probe marker with arbitrary values are inserted after TCP/UDP header as an indicator of INT existence. This probe marker was originally proposed by IETF draft https://tools.ietf.org/html/draft-lapukhov-dataplane-probe-01 (expired), and has been implemented by ASIC vendors.