### PR TITLE
Correction to the fixed header length in INT.mdk

### DIFF
--- a/telemetry/specs/INT.mdk
+++ b/telemetry/specs/INT.mdk
@@ -1139,7 +1139,7 @@ the INT metadata header.
 * The length (in bytes) of the INT metadata stack must always
 be a multiple of (Hop ML \* 4), plus the size of 'source-only' Domain Specific
 Metadata if added by the source. The total stack length can be determined
-by subtracting the total INT fixed header sizes (12 bytes)
+by subtracting the total INT fixed header sizes (16 bytes)
 from (shim header length \* 4).
 
 # Examples


### PR DESCRIPTION
Fixes #70 
With the addition of Domain Specific ID (2 bytes) ad Domain Specific Instruction (2 bytes), the new fixed header size is 16 bytes. This PR updates the INT fixed header size in Section 5.7 of INT.mdk.